### PR TITLE
"fixed numpy numba version incompatibility"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
 ]
-dependencies = ["numpy","scipy","numba"]
-
+dependencies = ["numpy<2.3","scipy","numba"]
 [project.urls]
 Homepage = "https://github.com/felipelewyee/PyNOF"
 


### PR DESCRIPTION
Numba requieres version lower than 2.3 for numpy.